### PR TITLE
Update actions/cache@v2 to actions/cache@v3

### DIFF
--- a/.github/workflows/c1.yaml
+++ b/.github/workflows/c1.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - name: Update the ${{ env.TAG_NAME }} tag
       id: update-major-tag
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         source-tag: ${{ env.TAG_NAME }}
         slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/c2.yaml
+++ b/.github/workflows/c2.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           days-before-issue-stale: 200
           days-before-issue-close: 5


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to use actions/cache@v3, as actions/cache@v2 is deprecated.